### PR TITLE
DateTime comparison and pubsub fixes post-con

### DIFF
--- a/lib/lanpartyseating/logic/badges_logic.ex
+++ b/lib/lanpartyseating/logic/badges_logic.ex
@@ -5,7 +5,6 @@ defmodule Lanpartyseating.BadgesLogic do
 
   def get_badge(uid) do
     min_uid = String.upcase(uid)
-    IO.inspect(min_uid)
 
     from(s in Badge,
       where: s.uid == ^min_uid

--- a/lib/lanpartyseating/logic/reservation_logic.ex
+++ b/lib/lanpartyseating/logic/reservation_logic.ex
@@ -44,8 +44,8 @@ defmodule Lanpartyseating.ReservationLogic do
               {:ok, updated} ->
                 Phoenix.PubSub.broadcast(
                   PubSub,
-                  "station_status",
-                  {:occupied, station_number, updated}
+                  "station_update",
+                  {:stations, StationLogic.get_all_stations(now)}
                 )
 
                 DynamicSupervisor.start_child(
@@ -84,8 +84,8 @@ defmodule Lanpartyseating.ReservationLogic do
 
           Phoenix.PubSub.broadcast(
             PubSub,
-            "station_status",
-            {:available, station_number}
+            "station_update",
+            {:stations, StationLogic.get_all_stations()}
           )
 
           struct

--- a/lib/lanpartyseating/logic/reservation_logic.ex
+++ b/lib/lanpartyseating/logic/reservation_logic.ex
@@ -14,8 +14,6 @@ defmodule Lanpartyseating.ReservationLogic do
       # Verifying that badge exists
       badge = BadgesLogic.get_badge(uid)
 
-      IO.inspect(badge)
-
       if badge == nil do
         {:error, "Unknown badge serial number"}
       else
@@ -59,7 +57,6 @@ defmodule Lanpartyseating.ReservationLogic do
                 {:ok, updated}
             end
           else
-            IO.inspect(label: "is not creatable")
             {:error, "Station is not available"}
           end
         end

--- a/lib/lanpartyseating/logic/station_logic.ex
+++ b/lib/lanpartyseating/logic/station_logic.ex
@@ -44,8 +44,6 @@ defmodule Lanpartyseating.StationLogic do
   end
 
   def set_station_broken(station_number, is_broken) do
-    IO.inspect(is_broken)
-
     station =
       Station
       |> where(station_number: ^station_number)

--- a/lib/lanpartyseating/logic/tournament_reservations_logic.ex
+++ b/lib/lanpartyseating/logic/tournament_reservations_logic.ex
@@ -1,4 +1,5 @@
 defmodule Lanpartyseating.TournamentReservationLogic do
+  alias Lanpartyseating.PubSub, as: PubSub
   alias Lanpartyseating.SettingsLogic, as: SettingsLogic
   alias Lanpartyseating.StationLogic, as: StationLogic
   alias Lanpartyseating.TournamentReservation, as: TournamentReservation
@@ -33,7 +34,15 @@ defmodule Lanpartyseating.TournamentReservationLogic do
           }
         end)
 
-        {:ok, Repo.insert_all(TournamentReservation, reservations)}
+        inserted = Repo.insert_all(TournamentReservation, reservations)
+
+        Phoenix.PubSub.broadcast(
+          PubSub,
+          "station_update",
+          {:stations, StationLogic.get_all_stations()}
+        )
+
+        {:ok, inserted}
     end
   end
 end

--- a/lib/lanpartyseating/tasks/expire_reservation.ex
+++ b/lib/lanpartyseating/tasks/expire_reservation.ex
@@ -3,6 +3,7 @@ defmodule Lanpartyseating.Tasks.ExpireReservation do
   import Ecto.Query
   import Ecto.Changeset
   require Logger
+  alias Lanpartyseating.StationLogic
   alias Lanpartyseating.Reservation, as: Reservation
   alias Lanpartyseating.Repo, as: Repo
   alias Lanpartyseating.PubSub, as: PubSub
@@ -50,8 +51,8 @@ defmodule Lanpartyseating.Tasks.ExpireReservation do
 
         Phoenix.PubSub.broadcast(
           PubSub,
-          "station_status",
-          {:available, reservation.station.station_number}
+          "station_update",
+          {:stations, StationLogic.get_all_stations()}
         )
     end
     {:stop, :normal, reservation_id}

--- a/lib/lanpartyseating/tasks/expire_tournament.ex
+++ b/lib/lanpartyseating/tasks/expire_tournament.ex
@@ -2,6 +2,7 @@ defmodule Lanpartyseating.Tasks.ExpireTournament do
   use GenServer, restart: :transient
   import Ecto.Query
   require Logger
+  alias Lanpartyseating.StationLogic
   alias Lanpartyseating.Tournament, as: Tournament
   alias Lanpartyseating.Repo, as: Repo
   alias Lanpartyseating.PubSub, as: PubSub
@@ -40,8 +41,8 @@ defmodule Lanpartyseating.Tasks.ExpireTournament do
     Enum.map(tournament.tournament_reservations, fn reservation ->
       Phoenix.PubSub.broadcast(
         PubSub,
-        "station_status",
-        {:available, reservation.station.station_number}
+        "station_update",
+        {:stations, StationLogic.get_all_stations()}
       )
     end)
 

--- a/lib/lanpartyseating/tasks/start_tournament.ex
+++ b/lib/lanpartyseating/tasks/start_tournament.ex
@@ -2,6 +2,7 @@ defmodule Lanpartyseating.Tasks.StartTournament do
   use GenServer, restart: :transient
   import Ecto.Query
   require Logger
+  alias Lanpartyseating.StationLogic
   alias Lanpartyseating.Tournament, as: Tournament
   alias Lanpartyseating.Repo, as: Repo
   alias Lanpartyseating.PubSub, as: PubSub
@@ -40,8 +41,8 @@ defmodule Lanpartyseating.Tasks.StartTournament do
     Enum.map(tournament.tournament_reservations, fn reservation ->
       Phoenix.PubSub.broadcast(
         PubSub,
-        "station_status",
-        {:reserved, reservation.station.station_number, reservation}
+        "station_update",
+        {:stations, StationLogic.get_all_stations()}
       )
     end)
     {:stop, :normal, tournament_id}

--- a/lib/lanpartyseating_web/live/cancellation_live.ex
+++ b/lib/lanpartyseating_web/live/cancellation_live.ex
@@ -10,7 +10,7 @@ defmodule LanpartyseatingWeb.CancellationLive do
     stations = StationLogic.get_all_stations()
 
     if connected?(socket) do
-      Phoenix.PubSub.subscribe(PubSub, "station_status")
+      Phoenix.PubSub.subscribe(PubSub, "station_update")
     end
 
     socket =
@@ -91,39 +91,8 @@ defmodule LanpartyseatingWeb.CancellationLive do
     {:noreply, socket}
   end
 
-  def handle_info({:available, station_number}, socket) do
-    new_stations =
-      socket.assigns.stations
-      |> Enum.map(fn s ->
-        if s.station.station_number == station_number,
-          do: Map.merge(s, %{status: :available, reservation: nil}),
-          else: s
-      end)
-
-    {:noreply, assign(socket, :stations, new_stations)}
-  end
-
-  def update_stations(old_stations, status, station_number, reservation) do
-    old_stations
-    |> Enum.map(fn s ->
-      if s.station.station_number == station_number,
-        do: Map.merge(s, %{status: status, reservation: reservation}),
-        else: s
-    end)
-  end
-
-  def handle_info({:occupied, station_number, reservation}, socket) do
-    new_stations =
-      update_stations(socket.assigns.stations, :occupied, station_number, reservation)
-
-    {:noreply, assign(socket, :stations, new_stations)}
-  end
-
-  def handle_info({:reserved, station_number, tournament_reservation}, socket) do
-    new_stations =
-      update_stations(socket.assigns.stations, :reserved, station_number, tournament_reservation)
-
-    {:noreply, assign(socket, :stations, new_stations)}
+  def handle_info({:stations, stations}, socket) do
+    {:noreply, assign(socket, :stations, stations)}
   end
 
   def render(assigns) do

--- a/lib/lanpartyseating_web/live/display_live.ex
+++ b/lib/lanpartyseating_web/live/display_live.ex
@@ -10,7 +10,7 @@ defmodule LanpartyseatingWeb.DisplayLive do
     tournaments = TournamentsLogic.get_upcoming_tournaments()
 
     if connected?(socket) do
-      Phoenix.PubSub.subscribe(PubSub, "station_status")
+      Phoenix.PubSub.subscribe(PubSub, "station_update")
     end
 
     socket =
@@ -28,38 +28,8 @@ defmodule LanpartyseatingWeb.DisplayLive do
     {:ok, socket}
   end
 
-  def handle_info({:available, seat_number}, socket) do
-    new_stations =
-      socket.assigns.stations
-      |> Enum.map(fn s ->
-        if s.station.station_number == seat_number,
-          do: Map.merge(s, %{status: :available, reservation: nil}),
-          else: s
-      end)
-
-    {:noreply, assign(socket, :stations, new_stations)}
-  end
-
-  def update_stations(old_stations, status, seat_number, reservation) do
-    old_stations
-    |> Enum.map(fn s ->
-      if s.station.station_number == seat_number,
-        do: Map.merge(s, %{status: status, reservation: reservation}),
-        else: s
-    end)
-  end
-
-  def handle_info({:occupied, seat_number, reservation}, socket) do
-    new_stations = update_stations(socket.assigns.stations, :occupied, seat_number, reservation)
-
-    {:noreply, assign(socket, :stations, new_stations)}
-  end
-
-  def handle_info({:reserved, seat_number, tournament_reservation}, socket) do
-    new_stations =
-      update_stations(socket.assigns.stations, :reserved, seat_number, tournament_reservation)
-
-    {:noreply, assign(socket, :stations, new_stations)}
+  def handle_info({:stations, stations}, socket) do
+    {:noreply, assign(socket, :stations, stations)}
   end
 
   def render(assigns) do

--- a/lib/lanpartyseating_web/live/display_live.ex
+++ b/lib/lanpartyseating_web/live/display_live.ex
@@ -70,9 +70,9 @@ defmodule LanpartyseatingWeb.DisplayLive do
           <h1 style="font-size:30px">Stations</h1>
           <div class="flex flex-wrap w-full">
             <%= for r <- 0..(@rows-1) do %>
-              <div class={"#{if rem(r,@rowpad) == rem(@row_trailing, @rowpad) and @rowpad != 1, do: "mb-4", else: ""} flex flex-row w-full "}>
+              <div class={"#{if rem(r,@rowpad) == rem(@row_trailing, @rowpad) and @rowpad != 1, do: "mb-4", else: ""} flex flex-row w-full"}>
                 <%= for c <- 0..(@columns-1) do %>
-                  <div class={"#{if rem(c,@colpad) == rem(@col_trailing, @colpad) and @colpad != 1, do: "mr-4", else: ""} flex flex-col h-14 flex-1 grow mx-1 "}>
+                  <div class={"#{if rem(c,@colpad) == rem(@col_trailing, @colpad) and @colpad != 1, do: "mr-4", else: ""} flex flex-col h-14 flex-1 grow mx-1"}>
                     <% station_data = assigns.stations |> Enum.at(r * @columns + c) %>
                     <%= if !is_nil(station_data) do %>
                     <DisplayModalComponent.modal reservation={station_data.reservation} station={station_data.station} status={station_data.status}/>
@@ -85,26 +85,26 @@ defmodule LanpartyseatingWeb.DisplayLive do
           <%!-- TOURNAMENTS --%>
           <h1 style="font-size:30px">Upcoming Tournaments / Tournois à venir</h1>
           <div class="flex flex-wrap w-full">
-            <div class="flex flex-row w-full border-b-4 " }>
-              <div class="flex flex-col flex-1 mx-1 h-14 grow justify-center border-r-2" }>
+            <div class="flex flex-row w-full border-b-4">
+              <div class="flex flex-col flex-1 mx-1 h-14 grow justify-center border-r-2">
                 <h2><b>Name / Nom</b></h2>
               </div>
-              <div class="flex flex-col flex-1 mx-1 h-14 grow justify-center border-r-2" }>
+              <div class="flex flex-col flex-1 mx-1 h-14 grow justify-center border-r-2">
                 <h2><b>Day / Jour</b></h2>
               </div>
-              <div class="flex flex-col flex-1 mx-1 h-14 grow justify-center border-r-2" }>
+              <div class="flex flex-col flex-1 mx-1 h-14 grow justify-center border-r-2">
                 <h2><b>Start Time / Début</b></h2>
               </div>
-              <div class="flex flex-col flex-1 mx-1 h-14 grow justify-center" }>
+              <div class="flex flex-col flex-1 mx-1 h-14 grow justify-center">
                 <h2><b>End Time / Fin</b></h2>
               </div>
             </div>
             <%= for tournament <- @tournaments do %>
-              <div class="flex flex-row w-full " }>
-                <div class="flex flex-col flex-1 mx-1 h-10 grow justify-center border-r-2" }>
+              <div class="flex flex-row w-full">
+                <div class="flex flex-col flex-1 mx-1 h-10 grow justify-center border-r-2">
                   <h3><%= tournament.name %></h3>
                 </div>
-                <div class="flex flex-col flex-1 mx-1 h-10 grow justify-center border-r-2" }>
+                <div class="flex flex-col flex-1 mx-1 h-10 grow justify-center border-r-2">
                   <h3>
                     <%= Calendar.strftime(
                       tournament.start_date |> Timex.to_datetime("America/Montreal"),
@@ -112,7 +112,7 @@ defmodule LanpartyseatingWeb.DisplayLive do
                     ) %>
                   </h3>
                 </div>
-                <div class="flex flex-col flex-1 mx-1 h-10 grow justify-center border-r-2" }>
+                <div class="flex flex-col flex-1 mx-1 h-10 grow justify-center border-r-2">
                   <h3>
                     <%= Calendar.strftime(
                       tournament.start_date |> Timex.to_datetime("America/Montreal"),
@@ -120,7 +120,7 @@ defmodule LanpartyseatingWeb.DisplayLive do
                     ) %>
                   </h3>
                 </div>
-                <div class="flex flex-col flex-1 mx-1 h-10 grow justify-center" }>
+                <div class="flex flex-col flex-1 mx-1 h-10 grow justify-center">
                   <h3>
                     <%= Calendar.strftime(
                       tournament.end_date |> Timex.to_datetime("America/Montreal"),

--- a/lib/lanpartyseating_web/live/selfsign_live.ex
+++ b/lib/lanpartyseating_web/live/selfsign_live.ex
@@ -11,6 +11,7 @@ defmodule LanpartyseatingWeb.SelfSignLive do
 
     if connected?(socket) do
       Phoenix.PubSub.subscribe(PubSub, "station_status")
+      Phoenix.PubSub.subscribe(PubSub, "station_update")
     end
 
     socket =
@@ -45,39 +46,8 @@ defmodule LanpartyseatingWeb.SelfSignLive do
     {:noreply, socket}
   end
 
-  def handle_info({:available, station_number}, socket) do
-    new_stations =
-      socket.assigns.stations
-      |> Enum.map(fn s ->
-        if s.station.station_number == station_number,
-          do: Map.merge(s, %{status: :available, reservation: nil}),
-          else: s
-      end)
-
-    {:noreply, assign(socket, :stations, new_stations)}
-  end
-
-  def update_stations(old_stations, status, station_number, reservation) do
-    old_stations
-    |> Enum.map(fn s ->
-      if s.station.station_number == station_number,
-        do: Map.merge(s, %{status: status, reservation: reservation}),
-        else: s
-    end)
-  end
-
-  def handle_info({:occupied, station_number, reservation}, socket) do
-    new_stations =
-      update_stations(socket.assigns.stations, :occupied, station_number, reservation)
-
-    {:noreply, assign(socket, :stations, new_stations)}
-  end
-
-  def handle_info({:reserved, station_number, tournament_reservation}, socket) do
-    new_stations =
-      update_stations(socket.assigns.stations, :reserved, station_number, tournament_reservation)
-
-    {:noreply, assign(socket, :stations, new_stations)}
+  def handle_info({:stations, stations}, socket) do
+    {:noreply, assign(socket, :stations, stations)}
   end
 
   def render(assigns) do

--- a/lib/lanpartyseating_web/live/selfsign_live.ex
+++ b/lib/lanpartyseating_web/live/selfsign_live.ex
@@ -88,9 +88,9 @@ defmodule LanpartyseatingWeb.SelfSignLive do
 
         <h1 style="font-size:20px">Please select an available station / Veuillez sélectionner une station disponible:</h1>
         <%= for r <- 0..(@rows-1) do %>
-          <div class={"#{if rem(r,@rowpad) == rem(@row_trailing, @rowpad) and @rowpad != 1, do: "mb-4", else: ""} flex flex-row w-full "}>
+          <div class={"#{if rem(r,@rowpad) == rem(@row_trailing, @rowpad) and @rowpad != 1, do: "mb-4", else: ""} flex flex-row w-full"}>
             <%= for c <- 0..(@columns-1) do %>
-              <div class={"#{if rem(c,@colpad) == rem(@col_trailing, @colpad) and @colpad != 1, do: "mr-4", else: ""} flex flex-col h-14 flex-1 grow mx-1 "}>
+              <div class={"#{if rem(c,@colpad) == rem(@col_trailing, @colpad) and @colpad != 1, do: "mr-4", else: ""} flex flex-col h-14 flex-1 grow mx-1"}>
                 <% station_data = @stations |> Enum.at(r * @columns + c) %>
                 <%= if !is_nil(station_data) do %>
                   <SelfSignModalComponent.modal

--- a/lib/lanpartyseating_web/live/tournaments_live.ex
+++ b/lib/lanpartyseating_web/live/tournaments_live.ex
@@ -100,28 +100,28 @@ defmodule LanpartyseatingWeb.TournamentsLive do
       <TournamentModalComponent.tournament_modal />
 
       <div class="flex flex-wrap w-full mt-3">
-        <div class="flex flex-row w-full " }>
-          <div class="flex flex-col flex-1 mx-1 h-14 grow" }>
+        <div class="flex flex-row w-full">
+          <div class="flex flex-col flex-1 mx-1 h-14 grow">
             <h2><u>Name</u></h2>
           </div>
-          <div class="flex flex-col flex-1 mx-1 h-14 grow" }>
+          <div class="flex flex-col flex-1 mx-1 h-14 grow">
             <h2><u>Start Time</u></h2>
           </div>
-          <div class="flex flex-col flex-1 mx-1 h-14 grow" }>
+          <div class="flex flex-col flex-1 mx-1 h-14 grow">
             <h2><u>End Time</u></h2>
           </div>
-          <div class="flex flex-col flex-1 mx-1 h-14 grow" }>
+          <div class="flex flex-col flex-1 mx-1 h-14 grow">
 
           </div>
         </div>
         <%= for tournament <- @tournaments do %>
-        <div class="flex flex-row w-full " }>
-          <div class="flex flex-col flex-1 mx-1 h-14 grow" }>
+        <div class="flex flex-row w-full">
+          <div class="flex flex-col flex-1 mx-1 h-14 grow">
             <h3>
               <%= tournament.name %>
             </h3>
           </div>
-          <div class="flex flex-col flex-1 mx-1 h-14 grow" }>
+          <div class="flex flex-col flex-1 mx-1 h-14 grow">
             <h3>
               <%=
 
@@ -131,7 +131,7 @@ defmodule LanpartyseatingWeb.TournamentsLive do
               ) %>
             </h3>
           </div>
-          <div class="flex flex-col flex-1 mx-1 h-14 grow" }>
+          <div class="flex flex-col flex-1 mx-1 h-14 grow">
             <h3>
               <%= Calendar.strftime(
                 tournament.end_date |> Timex.to_datetime("America/Montreal"),
@@ -139,7 +139,7 @@ defmodule LanpartyseatingWeb.TournamentsLive do
               ) %>
             </h3>
           </div>
-          <div class="flex flex-col flex-1 mx-1 h-14 grow" }>
+          <div class="flex flex-col flex-1 mx-1 h-14 grow">
             <form phx-submit="delete_tournament">
               <input type="hidden" name="tournament_id" value={tournament.id} />
               <button class="btn" type="submit" onclick={}>Delete</button>


### PR DESCRIPTION
This PR aims to address problem we either encountered during the 2023 convention or before but didn't have time to fix:

* Fix a time precision problem that would cause what looked like a race condition after creating a reservation. When creating a reservation and immediately querying all stations, the timestamp used in the second query would be truncated to the closest second, causing the timestamp for finding reservations to occur earlier in time than the actual creation timestamp of the reservation by a few ms, therefore causing the query to return no reservations for the station.

* Thanks to the previous fix, a lot of state management pubsub logic for station lifecycle was removed. Instead, the entire stations map is passed around via pubsub and assigned to the socket directly and phoenix takes care of updating the relevant pieces of pages, as intended by the framework.

* Removed noisy debug statements that should not have been committed