### PR TITLE
Upgrade to OTP 26, Elixir 1.15 and fix warns

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1688570050,
-        "narHash": "sha256-+msCZr8YMquz8mxllfskWKZHDl4039dC6NREy+nmHUI=",
+        "lastModified": 1694097209,
+        "narHash": "sha256-gQmBjjxeSyySjbh0yQVBKApo2KWIFqqbRUvG+Fa+QpM=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "c870687eb05076aec8754b671244a8423a12a924",
+        "rev": "7a8e6a91510efe89d8dcb8e43233f93e86f6b189",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1688466019,
-        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
+        "lastModified": 1693611461,
+        "narHash": "sha256-aPODl8vAgGQ0ZYFIRisxYG5MOGSkIczvu2Cd8Gb9+1Y=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
+        "rev": "7f53fdb7bdc5bb237da7fefef12d099e4fd611ca",
         "type": "github"
       },
       "original": {
@@ -156,11 +156,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1687467666,
-        "narHash": "sha256-z9n7ATBXeDqz5a8+4HJ9fhU6KMyg7zZX0wrhLdVG7bQ=",
+        "lastModified": 1688922987,
+        "narHash": "sha256-RnQwrCD5anqWfyDAVbfFIeU+Ha6cwt5QcIwIkaGRzQw=",
         "owner": "nlewo",
         "repo": "nix2container",
-        "rev": "56e249151911e3d3928b578f5b6c01b16f55c308",
+        "rev": "ab381a7d714ebf96a83882264245dbd34f0a7ec8",
         "type": "github"
       },
       "original": {
@@ -188,11 +188,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1688049487,
-        "narHash": "sha256-100g4iaKC9MalDjUW9iN6Jl/OocTDtXdeAj7pEGIRh4=",
+        "lastModified": 1693471703,
+        "narHash": "sha256-0l03ZBL8P1P6z8MaSDS/MvuU8E75rVxe5eE1N6gxeTo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bc72cae107788bf3f24f30db2e2f685c9298dc9",
+        "rev": "3e52e76b70d5508f3cec70b882a29199f4d1ee85",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1688556768,
-        "narHash": "sha256-mhd6g0iJGjEfOr3+6mZZOclUveeNr64OwxdbNtLc8mY=",
+        "lastModified": 1694251296,
+        "narHash": "sha256-l+1qRoMfUgn7SEKDu98ZPT8tCQxbqNadDHslSMtYb5Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "27bd67e55fe09f9d68c77ff151c3e44c4f81f7de",
+        "rev": "9108a20782535741433c304f6a4376cb8b364b89",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -67,8 +67,8 @@
         devenv.shells.default = let
           inherit (pkgs.lib) optional optionals;
           erlang = pkgs.beam.interpreters.erlangR25;
-          elixir = pkgs.beam.packages.erlangR25.elixir_1_14;
-          rebar = pkgs.beam.packages.erlangR25.rebar3;
+          elixir = pkgs.beam.packages.erlangR26.elixir_1_15;
+          rebar = pkgs.rebar3;
           nodejs = pkgs.nodejs_20;
         in {
           services.postgres = {

--- a/lib/lanpartyseating/logic/autoassign_logic.ex
+++ b/lib/lanpartyseating/logic/autoassign_logic.ex
@@ -2,7 +2,6 @@ defmodule Lanpartyseating.AutoAssignLogic do
   alias Lanpartyseating.LastAssignedSeat, as: LastAssignedStation
   alias Lanpartyseating.SettingsLogic, as: SettingsLogic
   alias Lanpartyseating.StationLogic, as: StationLogic
-  alias Lanpartyseating.Station, as: Station
   alias Lanpartyseating.Repo, as: Repo
 
   def register_station(uid) do

--- a/lib/lanpartyseating/logic/reservation_logic.ex
+++ b/lib/lanpartyseating/logic/reservation_logic.ex
@@ -64,7 +64,7 @@ defmodule Lanpartyseating.ReservationLogic do
     end
   end
 
-  def cancel_reservation(id, station_number, reason) do
+  def cancel_reservation(id, reason) do
     Reservation
     |> where(station_id: ^id)
     |> where([v], is_nil(v.deleted_at))

--- a/lib/lanpartyseating/logic/station_logic.ex
+++ b/lib/lanpartyseating/logic/station_logic.ex
@@ -142,7 +142,7 @@ defmodule Lanpartyseating.StationLogic do
     end)
   end
 
-  def get_station_status(station, now \\ DateTime.utc_now()) do
+  def get_station_status(station) do
     case station do
       %Station{is_closed: true} ->
         %{status: :broken, reservation: nil}

--- a/lib/lanpartyseating/repositories/station_status_repo.ex
+++ b/lib/lanpartyseating/repositories/station_status_repo.ex
@@ -14,8 +14,8 @@ defmodule Lanpartyseating.StationStatus do
 
   @doc false
   def changeset(reservation, attrs) do
-    #reservation
-    #|> cast(attrs, [:station_id, :tournament_id])
-    #|> validate_required([:station_id, :tournament_id])
+    reservation
+    |> cast(attrs, [:station_id, :tournament_id])
+    |> validate_required([:station_id, :tournament_id])
   end
 end

--- a/lib/lanpartyseating_web/live/cancellation_live.ex
+++ b/lib/lanpartyseating_web/live/cancellation_live.ex
@@ -46,19 +46,18 @@ defmodule LanpartyseatingWeb.CancellationLive do
 
     socket =
       socket
-      |> assign(:registration_error, nil)
+      |> assign(:registration_error, registration_error)
 
     {:noreply, socket}
   end
 
   def handle_event(
         "cancel_station",
-        %{"station_id" => id, "station_number" => station_number, "cancel_reason" => reason},
+        %{"station_id" => id, "station_number" => _station_number, "cancel_reason" => reason},
         socket
       ) do
     ReservationLogic.cancel_reservation(
       String.to_integer(id),
-      String.to_integer(station_number),
       reason
     )
 


### PR DESCRIPTION
* Upgrades all flake inputs
* Upgrades OTP 25 to 26
* Upgrades Elixir 1.14 to 1.15
* Fixes all compile warnings in the app and removes some unneeded logic along the way