### PR TITLE
Fix issues around tournament display and expiry

### DIFF
--- a/lib/lanpartyseating/logic/station_logic.ex
+++ b/lib/lanpartyseating/logic/station_logic.ex
@@ -13,7 +13,7 @@ defmodule Lanpartyseating.StationLogic do
   end
 
   def get_all_stations(now \\ DateTime.utc_now()) do
-    tournament_now = DateTime.add(DateTime.utc_now(), 45, :minute)
+    tournament_buffer = DateTime.add(DateTime.utc_now(), 45, :minute)
 
     stations =
       from(s in Station,
@@ -31,8 +31,8 @@ defmodule Lanpartyseating.StationLogic do
           tournament_reservations:
             ^from(tr in TournamentReservation,
               join: t in assoc(tr, :tournament),
-              where: t.start_date < ^tournament_now,
-              where: t.end_date > ^tournament_now,
+              where: t.start_date < ^tournament_buffer,
+              where: t.end_date > ^now,
               where: is_nil(t.deleted_at),
               preload: [tournament: t]
             )
@@ -69,7 +69,7 @@ defmodule Lanpartyseating.StationLogic do
   end
 
   def get_all_stations_sorted_by_number(now \\ DateTime.utc_now()) do
-    tournament_now = DateTime.add(DateTime.utc_now(), 45, :minute)
+    tournament_buffer = DateTime.add(DateTime.utc_now(), 45, :minute)
 
     stations =
       from(s in Station,
@@ -87,8 +87,8 @@ defmodule Lanpartyseating.StationLogic do
           tournament_reservations:
             ^from(tr in TournamentReservation,
               join: t in assoc(tr, :tournament),
-              where: t.start_date < ^tournament_now,
-              where: t.end_date > ^tournament_now,
+              where: t.start_date < ^tournament_buffer,
+              where: t.end_date > ^now,
               where: is_nil(t.deleted_at),
               preload: [tournament: t]
             )
@@ -102,7 +102,7 @@ defmodule Lanpartyseating.StationLogic do
   end
 
   def get_station(station_number, now \\ DateTime.utc_now()) do
-    tournament_now = DateTime.add(DateTime.utc_now(), 45, :minute)
+    tournament_buffer = DateTime.add(DateTime.utc_now(), 45, :minute)
 
     from(s in Station,
       order_by: [asc: s.id],
@@ -120,8 +120,8 @@ defmodule Lanpartyseating.StationLogic do
         tournament_reservations:
           ^from(tr in TournamentReservation,
             join: t in assoc(tr, :tournament),
-            where: t.start_date < ^tournament_now,
-            where: t.end_date > ^tournament_now,
+            where: t.start_date < ^tournament_buffer,
+            where: t.end_date > ^now,
             where: is_nil(t.deleted_at),
             preload: [tournament: t]
           )

--- a/lib/lanpartyseating/tasks/expire_tournament.ex
+++ b/lib/lanpartyseating/tasks/expire_tournament.ex
@@ -1,6 +1,7 @@
 defmodule Lanpartyseating.Tasks.ExpireTournament do
   use GenServer, restart: :transient
   require Logger
+  alias Lanpartyseating.TournamentsLogic
   alias Lanpartyseating.StationLogic
   alias Lanpartyseating.PubSub, as: PubSub
 
@@ -26,6 +27,12 @@ defmodule Lanpartyseating.Tasks.ExpireTournament do
   @impl true
   def handle_info(:expire_tournament, tournament_id) do
     Logger.debug("Expiring tournament #{tournament_id}")
+
+    Phoenix.PubSub.broadcast(
+      PubSub,
+      "tournament_update",
+      {:tournaments, TournamentsLogic.get_upcoming_tournaments()}
+    )
 
     Phoenix.PubSub.broadcast(
       PubSub,

--- a/lib/lanpartyseating_web/components/selfsign_modal.ex
+++ b/lib/lanpartyseating_web/components/selfsign_modal.ex
@@ -27,7 +27,7 @@ defmodule SelfSignModalComponent do
         <div class="modal modal-bottom sm:modal-middle">
           <div class="modal-box">
             <h3 class="text-lg font-bold">Station #<%= @station.station_number %></h3>
-            <p>Once you badge is scanned, a 45 min session will start at the chosen station</p>
+            <p>Once your badge is scanned, a 45 min session will start at the chosen station</p>
             <br />
             <p>Une fois votre badge scanné, une session de 45 min commencera à la station choisie</p>
 

--- a/lib/lanpartyseating_web/live/display_live.ex
+++ b/lib/lanpartyseating_web/live/display_live.ex
@@ -24,7 +24,6 @@ defmodule LanpartyseatingWeb.DisplayLive do
       |> assign(:rowpad, settings.row_padding)
       |> assign(:stations, StationLogic.get_all_stations())
       |> assign(:tournaments, tournaments)
-      |> assign(:tournamentsCount, length(tournaments))
 
     {:ok, socket}
   end

--- a/lib/lanpartyseating_web/live/tournaments_live.ex
+++ b/lib/lanpartyseating_web/live/tournaments_live.ex
@@ -9,7 +9,6 @@ defmodule LanpartyseatingWeb.TournamentsLive do
     socket =
       socket
       |> assign(:tournaments, tournaments)
-      |> assign(:tournamentsCount, length(tournaments))
 
     {:ok, socket}
   end


### PR DESCRIPTION
* Fix stations showing available 45 minutes before the end of a tournament
* Fix tournament start and expiry tasks not being scheduled
* Small clean up