### PR TITLE
Allow reservation time to be extended

### DIFF
--- a/lib/lanpartyseating/logic/reservation_logic.ex
+++ b/lib/lanpartyseating/logic/reservation_logic.ex
@@ -43,7 +43,8 @@ defmodule Lanpartyseating.ReservationLogic do
               "new_reservation",
               %{
                 station_number: station_number,
-                # reservation: updated
+                start_date: updated.start_date |> DateTime.to_iso8601(),
+                end_date: updated.end_date |> DateTime.to_iso8601(),
               }
             )
 

--- a/lib/lanpartyseating_web/components/cancellation_modal.ex
+++ b/lib/lanpartyseating_web/components/cancellation_modal.ex
@@ -74,10 +74,28 @@ defmodule CancellationModalComponent do
                   "%H:%M"
                 ) %> *REPLACE WITH COUNTDOWN*</b>
                 </p>
-                <p class="py-4">Enter a reason for canceling the reservation</p>
                 <form method="dialog">
                   <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
                 </form>
+
+                <p class="py-4">Enter an amount of minutes to extend the reservation by</p>
+
+                <form phx-submit="extend_reservation">
+                  <input type="hidden" name="station_id" value={"#{@station.id}"}>
+                  <input type="hidden" name="station_number" value={"#{@station.station_number}"}>
+                  <input type="text" placeholder="Minutes to add" value="5" class="w-full max-w-xs input input-bordered" name="minutes_increment"/>
+
+                  <div class="modal-action">
+                    <button
+                      class="btn btn-success"
+                      x-on:click={"$refs.station_modal_#{@station.station_number}.close()"}
+                      type="submit">
+                      Add time to reservation
+                    </button>
+                  </div>
+                </form>
+
+                <p class="py-4">Enter a reason for canceling the reservation</p>
 
                 <form phx-submit="cancel_station">
                   <input type="hidden" name="station_id" value={"#{@station.id}"}>

--- a/lib/lanpartyseating_web/live/cancellation_live.ex
+++ b/lib/lanpartyseating_web/live/cancellation_live.ex
@@ -52,6 +52,19 @@ defmodule LanpartyseatingWeb.CancellationLive do
   end
 
   def handle_event(
+        "extend_reservation",
+        %{"station_id" => id, "station_number" => _station_number, "minutes_increment" => minutes},
+        socket
+      ) do
+    {:ok, _} = ReservationLogic.extend_reservation(
+      String.to_integer(id),
+      String.to_integer(minutes)
+    )
+
+    {:noreply, socket}
+  end
+
+  def handle_event(
         "cancel_station",
         %{"station_id" => id, "station_number" => _station_number, "cancel_reason" => reason},
         socket


### PR DESCRIPTION
Sometimes, we want to give gamers additional time on their reservation to finish a match for example. This PR adds a (pretty terrible) user interface to the "Cancellation" page that allows an operator to extend a session by a set amount of minutes as well as cancelling it. The cancellation page should probably be renamed to something more generic like "station management" to reflect this change in functionality.

The new cancellation modal with these changes:
<img width="1676" alt="Screenshot 2024-01-24 at 01 23 53" src="https://github.com/otakulan/lanparty-seating/assets/1858154/ee0e2651-4603-46c0-96f1-78e6f13ab4dc">
