### PR TITLE
Remove badge number history that shows up under the badge input field

### DIFF
--- a/lib/lanpartyseating_web/components/selfsign_modal.ex
+++ b/lib/lanpartyseating_web/components/selfsign_modal.ex
@@ -47,6 +47,7 @@ defmodule SelfSignModalComponent do
                     placeholder="Badge number / Numéro de badge"
                     class="w-full max-w-xs input input-bordered"
                     name="uid"
+                    autocomplete="off"
                     autofocus
                   />
 

--- a/lib/lanpartyseating_web/live/autoassign_live.ex
+++ b/lib/lanpartyseating_web/live/autoassign_live.ex
@@ -50,6 +50,7 @@ defmodule LanpartyseatingWeb.AutoAssignLive do
           placeholder="Badge number"
           class="w-full max-w-xs input input-bordered"
           name="uid"
+          autocomplete="off"
           autofocus
         />
 


### PR DESCRIPTION
Change was tested by adding the HTML attribute in the kiosk's UI. 