### PR TITLE
Make station layout rotation display properly

### DIFF
--- a/lib/lanpartyseating/logic/station_logic.ex
+++ b/lib/lanpartyseating/logic/station_logic.ex
@@ -163,7 +163,6 @@ defmodule Lanpartyseating.StationLogic do
           %{station_number: station_number, display_order: station_number, inserted_at: now_naive, updated_at: now_naive}
         end)
       end)
-      |> IO.inspect
 
     Repo.insert_all(Station, positions)
     :ok

--- a/lib/lanpartyseating_web/live/cancellation_live.ex
+++ b/lib/lanpartyseating_web/live/cancellation_live.ex
@@ -15,8 +15,8 @@ defmodule LanpartyseatingWeb.CancellationLive do
 
     socket =
       socket
-      |> assign(:columns, settings.columns)
-      |> assign(:rows, settings.rows)
+      |> assign(:columns, if(settings.is_diagonally_mirrored, do: settings.rows, else: settings.columns))
+      |> assign(:rows, if(settings.is_diagonally_mirrored, do: settings.columns, else: settings.rows))
       |> assign(:col_trailing, settings.vertical_trailing)
       |> assign(:row_trailing, settings.horizontal_trailing)
       |> assign(:colpad, settings.column_padding)

--- a/lib/lanpartyseating_web/live/display_live.ex
+++ b/lib/lanpartyseating_web/live/display_live.ex
@@ -17,8 +17,8 @@ defmodule LanpartyseatingWeb.DisplayLive do
 
     socket =
       socket
-      |> assign(:columns, settings.columns)
-      |> assign(:rows, settings.rows)
+      |> assign(:columns, if(settings.is_diagonally_mirrored, do: settings.rows, else: settings.columns))
+      |> assign(:rows, if(settings.is_diagonally_mirrored, do: settings.columns, else: settings.rows))
       |> assign(:col_trailing, settings.vertical_trailing)
       |> assign(:row_trailing, settings.horizontal_trailing)
       |> assign(:colpad, settings.column_padding)

--- a/lib/lanpartyseating_web/live/selfsign_live.ex
+++ b/lib/lanpartyseating_web/live/selfsign_live.ex
@@ -16,8 +16,8 @@ defmodule LanpartyseatingWeb.SelfSignLive do
 
     socket =
       socket
-      |> assign(:columns, settings.columns)
-      |> assign(:rows, settings.rows)
+      |> assign(:columns, if(settings.is_diagonally_mirrored, do: settings.rows, else: settings.columns))
+      |> assign(:rows, if(settings.is_diagonally_mirrored, do: settings.columns, else: settings.rows))
       |> assign(:col_trailing, settings.vertical_trailing)
       |> assign(:row_trailing, settings.horizontal_trailing)
       |> assign(:colpad, settings.column_padding)

--- a/lib/lanpartyseating_web/live/settings_live.ex
+++ b/lib/lanpartyseating_web/live/settings_live.ex
@@ -154,6 +154,7 @@ defmodule LanpartyseatingWeb.SettingsLive do
       socket
       |> assign(:rows, socket.assigns.rows)
       |> assign(:columns, socket.assigns.columns)
+      |> assign(:is_diagnoally_mirrored, !socket.assigns.is_diagonally_mirrored)
       |> assign(:table, transpose(socket.assigns.table))
 
     {:noreply, socket}
@@ -176,7 +177,7 @@ defmodule LanpartyseatingWeb.SettingsLive do
 
     :ok = Lanpartyseating.StationLogic.save_station_positions(socket.assigns.table)
 
-    {:ok, _} = Lanpartyseating.SettingsLogic.save_settings(
+    :ok = Lanpartyseating.SettingsLogic.save_settings(
       s.rows,
       s.columns,
       s.rowpad,


### PR DESCRIPTION
We need to account for a row/col swap when the stations are diagonally flipped